### PR TITLE
refactor and fix code style

### DIFF
--- a/Controller/CitrixController.php
+++ b/Controller/CitrixController.php
@@ -59,8 +59,8 @@ class CitrixController extends Controller
 
             if($status){
                 try {
-                    $repository = $this->getDoctrine()->getManager();
-                    $repository->getConnection()->beginTransaction();
+                    $em = $this->getDoctrine()->getManager();
+                    $em->getConnection()->beginTransaction();
 
                     $wizard = $this->get('campaignchain.core.channel.wizard');
                     $wizard->setName($profile->displayName);
@@ -88,17 +88,17 @@ class CitrixController extends Controller
                     $user->setLastName($profile->lastName);
                     $user->setEmail($profile->email);
 
-                    $repository->persist($user);
-                    $repository->flush();
+                    $em->persist($user);
+                    $em->flush();
 
-                    $repository->getConnection()->commit();
+                    $em->getConnection()->commit();
 
                     $this->get('session')->getFlashBag()->add(
                         'success',
                         'The Citrix location <a href="#">'.$profile->displayName.'</a> was connected successfully.'
                     );
                 } catch (\Exception $e) {
-                    $repository->getConnection()->rollback();
+                    $em->getConnection()->rollback();
                     throw $e;
                 }
             } else {


### PR DESCRIPTION
- fix code style
- extract queries to CampaignChainCoreBundle:Campaign repository
- remove unused namespace imports
- extract form generation to getCampaignType() to reduce boiler plate
- use $this->addFlash() instead of $this->get('session')->getFlashBag()->add()
- use $this->redirectToRoute() instead of $this->redirect($this->generateUrl())
- rename $repository to $em, because it contains the Entity Manager and not a repository
- replace serializer generation with a serializer service to reduce boiler plate
- inject serializer service where necessary
- remove unnecessary $response variable
- remove unnecessary $response->setStatusCode(Response::HTTP_OK) - it's already the default
